### PR TITLE
Pull in django-model-changes 0.15 changes

### DIFF
--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -95,16 +95,33 @@ class ChangesMixin(object):
         if not new_instance:
             post_change.send(sender=self.__class__, instance=self)
 
+    def _instance_from_state(self, state):
+        """
+        Creates an instance from a previously saved state.
+        """
+        instance = self.__class__()
+        for key, value in state.items():
+            setattr(instance, key, value)
+        return instance
+
     def current_state(self):
         """
         Returns a ``field -> value`` dict of the current state of the instance.
         """
-        field_names = set()
-        [field_names.add(f.name) for f in self._meta.local_fields]
+        fields = {}
+        for field in self._meta.local_fields:
+            # It's always safe to access the field attribute name, it refers to simple types that are immediately
+            # available on the instance.
+            fields[field.attname] = getattr(self, field.attname, None)
 
-        [field_names.add(f.attname) for f in self._meta.local_fields]
-        return dict([(field_name, getattr(self, field_name, None)) \
-                     for field_name in field_names])
+            # Foreign fields require special care because we don't want to trigger a database query when the field is
+            # not yet cached.
+            if field.rel:
+                descriptor = self.__class__.__dict__[field.name]
+                if hasattr(self, descriptor.cache_name):
+                    fields[field.name] = getattr(self, descriptor.cache_name, None)
+
+        return fields
 
     def previous_state(self):
         """
@@ -191,13 +208,13 @@ class ChangesMixin(object):
         """
         Returns an instance of this model in its old state.
         """
-        return self.__class__(**self.old_state())
+        return self._instance_from_state(self.old_state())
 
     def previous_instance(self):
         """
         Returns an instance of this model in its previous state.
         """
-        return self.__class__(**self.previous_state())
+        return self._instance_from_state(self.previous_state())
 
 
 def _post_save(sender, instance, **kwargs):


### PR DESCRIPTION
This repo didn't contain the latest 0.15 changes that were made to the python2 version of django-model-changes. This PR pulls those changes in and ensure that they are modified as appropriate to maintain python3 support.